### PR TITLE
Prettying up the comment face code

### DIFF
--- a/style.css
+++ b/style.css
@@ -1415,153 +1415,8 @@ html:not(:lang(en)) .side [href$="#w"]+em:after {
 }
 
 /** Comment faces! something something urban's domain - he writes shit code but we love him anyway <3 **/
-.md [href="#gendo-pls"],.md [href="#k-on-hug"],.md [href="#lewd"],.md [href="#nanami-hug"],.md [href="#yui-crying"],.md [href="#ok"]{background-image:url(%%spritesheet1%%)}
-.md [href="#gendo-pls"]{width:171px;height:114px;background-position:0 -520px}
-.md [href="#k-on-hug"]{width:180px;height:120px;background-position:0 -814px}
-.md [href="#lewd"]{width:100px;height:150px;background-position:0 -984px}
-.md [href="#nanami-hug"]{width:120px;height:150px;background-position:0 -1184px}
-.md [href="#yui-crying"]{width:80px;height:80px;background-position:0 -1644px}
-.md [href="#ok"]{width:100px;height:100px;background-position:-100px 0}
-.md [href="#stare"],.md [href="#what"]{background-image:url(%%spritesheet2%%)}
-.md [href="#stare"]{width:150px;height:100px;background-position:0 -780px}
-.md [href="#what"]{width:100px;height:80px;background-position:0 -1060px}
-.md [href="#gununu"]{background-image:url(%%spritesheet3%%);display:inline-block;width:107px;height:80px;background-position:0 -780px}
-.md [href="#facepalm"],.md [href="#nico-heart"],.md [href="#thumbs-up"],.md [href="#kukuku"]{background-image:url(%%spritesheet4%%)}
-.md [href="#facepalm"]{width:80px;height:80px;background-position:0 0}
-.md [href="#nico-heart"]{width:100px;height:80px;background-position:0 -520px}
-.md [href="#thumbs-up"]{width:120px;height:100px;background-position:0 -1430px}
-.md [href="#kukuku"]{width:100px;height:150px;background-position:-170px -390px}
-.md [href="#kotori"],.md [href="#araragi-1"],.md [href="#deadpan"],.md [href="#head-tilt"],.md [href="#manly-tears"],.md [href="#not-raining"],.md [href="#ohmygod"],.md [href="#shock"],.md [href="#heart-thumbs-up"],.md [href="#wow-really"]{background-image:url(%%spritesheet5%%)}
-.md [href="#kotori"]{width:85px;height:89px;background-position:-215px -5px}
-.md [href="#araragi-1"]{width:100px;height:50px;background-position:-5px -95px}
-.md [href="#deadpan"]{width:80px;height:85px;background-position:-300px -155px}
-.md [href="#head-tilt"]{width:121px;height:100px;background-position:-312px -290px}
-.md [href="#manly-tears"]{width:150px;height:100px;background-position:-445px -5px}
-.md [href="#not-raining"]{width:146px;height:100px;background-position:-480px -115px}
-.md [href="#ohmygod"]{width:175px;height:100px;background-position:-443px -290px}
-.md [href="#shock"]{width:170px;height:100px;background-position:-115px -400px}
-.md [href="#heart-thumbs-up"]{width:79px;height:100px;background-position:-295px -400px}
-.md [href="#wow-really"]{width:80px;height:85px;background-position:-564px -400px}
-@keyframes urbansmile{from{background-position:0 -11522px}
-to{background-position:0 -8954px}}
-.md [href="#urbansmile"]{height:105px;width:191px;background:url(%%SoloSheet%%) 0 -11522px no-repeat}
-.md [href="#urbansmile"]:hover{animation:urbansmile 1.46s steps(24);animation-fill-mode:forwards}
-@keyframes hyoukawink{from{background-position:0 -1342px}
-to{background-position:0 0}}
-.md [href="#hyoukawink"]{height:120px;width:191px;background:url(%%SoloSheet%%) -0px -1342px no-repeat}
-.md [href="#hyoukawink"]:hover{animation:hyoukawink 1.8s steps(11);animation-fill-mode:forwards}
-@keyframes peasants{from{background-position:0 -13769px}
-to{background-position:0 -11629px}}
-.md [href="#peasants"]{height:105px;width:190px;background:url(%%SoloSheet%%) -0px -13769px no-repeat}
-.md [href="#peasants"]:hover{animation:peasants 1.2s steps(20);animation-fill-mode:forwards}
-@keyframes yousaidsomethingdumb{from{background-position:0 -8847px}
-to{background-position:0 -3604px}}
-.md [href="#yousaidsomethingdumb"]{height:105px;width:191px;background:url(%%SoloSheet%%) -0px -8847px no-repeat}
-.md [href="#yousaidsomethingdumb"]:hover{animation:yousaidsomethingdumb 2.5s steps(49);animation-fill-mode:forwards}
-@keyframes hajimepout{from{background-position:0 -3497px}
-to{background-position:0 -1464px}}
-.md [href="#hajimepout"]{height:105px;width:191px;background:url(%%SoloSheet%%) -0px -3497px no-repeat}
-.md [href="#hajimepout"]:hover{animation:hajimepout 1.74s steps(19);animation-fill-mode:forwards}
-@keyframes excitedyui{from{background-position:0 0}
-to{background-position:0 -1148px}}
-.md [href="#excitedyui"]{height:162px;width:122px;background:url(%%animatedsheet1%%) -0px 0 no-repeat}
-.md [href="#excitedyui"]:hover{animation:excitedyui .8s steps(7) infinite}
-@keyframes banjo{from{background-position:0 -5029px}
-to{background-position:0 -1605px}}
-.md [href="#banjo"]{height:105px;width:191px;background:url(%%DrPepperSheet%%) -0px -5029px no-repeat}
-.md [href="#banjo"]:hover{animation:banjo 1.44s steps(32);animation-fill-mode:forwards}
-@keyframes slightoverreaction{from{background-position:0 -13375px}
-to{background-position:0 -5136px}}
-.md [href="#slightoverreaction"]{height:105px;width:191px;background:url(%%DrPepperSheet%%) -0px -13375px no-repeat}
-.md [href="#slightoverreaction"]:hover{animation:slightoverreaction 6.24s steps(77) infinite}
-@keyframes anko{from{background-position:0 -1498px}
-to{background-position:0 0}}
-.md [href="#anko"]{height:105px;width:191px;background:url(%%DrPepperSheet%%) -0px -1498px no-repeat}
-.md [href="#anko"]:hover{animation:anko 1.8s steps(14);animation-fill-mode:forwards}
-ele{color:#f00}
-.md [href="#badassmugi"]{background:0 -2922px}
-.md [href="#banjoisahellofadrug"]{background:0 -3022px}
-.md [href="#bearhug"]{background:0 -3122px}
-.md [href="#bearwithme"]{background:0 -3222px}
-.md [href="#biribiricat"]{background:0 -3322px}
-.md [href="#csikon"]{background:0 -3622px}
-.md [href="#elsieqq"]{background:0 -3922px}
-.md [href="#flclawe"]{height:133px!important;background:0 -841px}
-.md [href="#haruhiisnotamused"]{background:0 -4222px}
-.md [href="#hisokaclown"]{background:0 -4422px}
-.md [href="#hanasakueurgh"]{background:0 -4122px}
-.md [href="#jibrilaww"]{background:0 -4622px}
-.md [href="#jibrilfetish"]{background:0 -4722px}
-.md [href="#katoupls"]{background:0 -4922px}
-.md [href="#mechablush"]{background:0 -5222px}
-.md [href="#miiaembarassed"]{background:0 -5422px}
-.md [href="#misakiteehee"]{background:0 -5622px}
-.md [href="#misakiwink"]{background:0 -5722px}
-.md [href="#nononkek"]{background:0 -5822px}
-.md [href="#ohgodwhathaveidone"]{background:0 -6022px}
-.md [href="#smugpoint"]{background:0 -6622px}
-.md [href="#smugshinobu"]{background:0 -6722px}
-.md [href="#SPORTS"]{background:0 -6922px}
-.md [href="#whowouldathunkit"]{background:0 -7822px}
-.md [href="#yandereyuno"]{background:0 -8022px}
-.md [href="#cup2"]{background:0 -3722px}
-.md [href="#annoyedkirito"]{height:113px!important;background:0 -2472px}
-.md [href="#bestiathumbsup"]{height:133px!important;background:0 -706px}
-.md [href="#crazedlaugh"]{height:119px!important;background:0 -1879px}
-.md [href="#cup1"]{height:124px!important;background:0 -1508px}
-.md [href="#gintamaspillage"]{height:129px!important;background:0 -1377px}
-.md [href="#hunchedover"]{height:141px!important;background:0 -144px}
-.md [href="#hypeoverload"]{width:125px!important;height:150px!important;background:0 -8122px}
-.md [href="#infernocopu"]{width:125px!important;height:123px!important;background:0 -8274px}
-.md [href="#niatilt"]{height:114px!important;background:0 -2704px}
-.md [href="#nosepick"]{height:116px!important;background:0 -2119px}
-.md [href="#mug1"]{height:131px!important;background:0 -1111px}
-.md [href="#mug3"]{height:131px!important;background:0 -1244px}
-.md [href="#badassmugi"],.md [href="#banjoisahellofadrug"],.md [href="#bearhug"],.md [href="#bearwithme"],.md [href="#biribiricat"],.md [href="#csikon"],.md [href="#elsieqq"],.md [href="#haruhiisnotamused"],.md [href="#hisokaclown"],.md [href="#hanasakueurgh"],.md [href="#jibrilaww"],.md [href="#jibrilfetish"],.md [href="#katoupls"],.md [href="#mechablush"],.md [href="#miiaembarassed"],.md [href="#misakiteehee"],.md [href="#misakiwink"],.md [href="#nononkek"],.md [href="#ohgodwhathaveidone"],.md [href="#smugpoint"],.md [href="#smugshinobu"],.md [href="#SPORTS"],.md [href="#whowouldathunkit"],.md [href="#yandereyuno"],.md [href="#cup2"],.md [href="#annoyedkirito"],.md [href="#bestiathumbsup"],.md [href="#flclawe"],.md [href="#crazedlaugh"],.md [href="#cup1"],.md [href="#gintamaspillage"],.md [href="#hunchedover"],.md [href="#hypeoverload"],.md [href="#infernocopu"],.md [href="#niatilt"],.md [href="#nosepick"],.md [href="#mug1"],.md [href="#mug3"]{background-image:url(%%StaticSpriteSheet1%%);width:178px;height:98px}
-.md [href="#akyuusqueel"],.md [href="#arakawascream"],.md [href="#asunanotamused"],.md [href="#barakamonnotcool"],.md [href="#bestiacheckyourprivilage"],.md [href="#chiyomad"],.md [href="#comewithmeifyouwanttobebestgirl"],.md [href="#crazyhatgirlexcited"],.md [href="#disbelief"],.md [href="#dontdometh"],.md [href="#duckhue"],.md [href="#embarassedisla"],.md [href="#gintamacrushed"],.md [href="#gintamasunlight"],.md [href="#gintamathispleasesme"],.md [href="#happypoi"],.md [href="#izananotthisshitagain"],.md [href="#katoupout"],.md [href="#nocomment"],.md [href="#kumikouninterested"],.md [href="#kyonfacepalm"],.md [href="#maidshock"],.md [href="#marikalewd"],.md [href="#mug2"],.md [href="#nichijouqq"],.md [href="#rengehype"],.md [href="#scaredmio"],.md [href="#sheerdisgust"],.md [href="#smugillya"],.md [href="#smuglancer"],.md [href="#thoughtful"],.md [href="#trollarcher"],.md [href="#uglycry"],.md [href="#vashheadscratch"],.md [href="#WRYYY"],.md [href="#yuruyuriapprove"],.md [href="#happydera"],.md [href="#holdme"],.md [href="#misakaheh"],.md [href="#ohnoudidnt"],.md [href="#teehee"],.md [href="#tiredfate"],.md [href="#chitogheh"]{background:url(%%StaticSpriteSheet2%%);width:178px;height:98px}
-.md [href="#akyuusqueel"]{width:129px;height:121px;background-position:0 -8621px}
-.md [href="#arakawascream"]{width:143px;height:117px;background-position:0 -7733px}
-.md [href="#asunanotamused"]{width:125px;height:118px;background-position:0 -10136px}
-.md [href="#barakamonnotcool"]{background-position:0 -400px}
-.md [href="#bestiacheckyourprivilage"]{width:123px;height:106px;background-position:0 -10615px}
-.md [href="#chiyomad"]{background-position:0 -700px}
-.md [href="#comewithmeifyouwanttobebestgirl"]{background-position:0 -800px}
-.md [href="#crazyhatgirlexcited"]{background-position:0 -1000px}
-.md [href="#disbelief"]{width:125px;height:119px;background-position:0 -10015px}
-.md [href="#dontdometh"]{width:143px;height:96px;background-position:0 -8410px}
-.md [href="#duckhue"]{width:143px;height:122px;background-position:0 -7485px}
-.md [href="#embarassedisla"]{background-position:0 -1100px}
-.md [href="#gintamacrushed"]{background-position:0 -1600px}
-.md [href="#gintamasunlight"]{background-position:0 -2000px}
-.md [href="#gintamathispleasesme"]{width:143px;height:141px;background-position:0 -6403px}
-.md [href="#happypoi"]{width:143px;height:142px;background-position:0 -6259px}
-.md [href="#izananotthisshitagain"]{width:125px;height:135px;background-position:0 -9616px}
-.md [href="#katoupout"]{background-position:0 -2300px}
-.md [href="#nocomment"]{background-position:0 -2400px}
-.md [href="#kumikouninterested"]{width:125px;height:140px;background-position:0 -9336px}
-.md [href="#kyonfacepalm"]{background-position:0 -2500px}
-.md [href="#maidshock"]{width:107px;height:106px;background-position:0 -10978px}
-.md [href="#marikalewd"]{width:125px;height:157px;background-position:0 -8864px}
-.md [href="#mug2"]{width:143px;height:105px;background-position:0 -8198px}
-.md [href="#nichijouqq"]{width:123px;height:118px;background-position:0 -8744px}
-.md [href="#rengehype"]{background-position:0 -3000px}
-.md [href="#scaredmio"]{width:123px;height:154px;background-position:0 -10822px}
-.md [href="#sheerdisgust"]{width:143px;height:158px;background-position:0 -6097px}
-.md [href="#smugillya"]{width:142px;height:128px;background-position:0 -7228px}
-.md [href="#smuglancer"]{width:143px;height:122px;background-position:0 -7609px}
-.md [href="#thoughtful"]{width:143px;height:114px;background-position:0 -7852px}
-.md [href="#trollarcher"]{width:125px;height:154px;background-position:0 -9180px}
-.md [href="#uglycry"]{background-position:0 -4000px}
-.md [href="#vashheadscratch"]{width:143px;height:103px;background-position:0 -8305px}
-.md [href="#WRYYY"]{background-position:0 -4100px}
-.md [href="#yuruyuriapprove"]{background-position:0 -4400px}
-.md [href="#happydera"]{background-position:0 -4500px}
-.md [href="#holdme"]{background-position:0 -4600px}
-.md [href="#misakaheh"]{background-position:0 -4700px}
-.md [href="#ohnoudidnt"]{background-position:0 -4800px}
-.md [href="#teehee"]{width:155px;height:122px;background-position:0 -5408px}
-.md [href="#tiredfate"]{background-position:0 -5200px}
-.md [href="#chitogheh"]{background-position:0 0}
+
+/** Animated Set #1 **/
 @keyframes breakingnews{from{background-position:0 -9197px}
 to{background-position:0 -8387px}}
 .md [href="#breakingnews"]{height:133px;width:176px;background:url(%%FantaSheet%%) -0px -9197px no-repeat}
@@ -1622,6 +1477,10 @@ to{background-position:0 -7490px}}
 to{background-position:0 -1605px}}
 .md [href="#missedthepoint"]{height:105px;width:191px;background:url(%%AnythingButPepsiSheet%%) -0px -4066px no-repeat}
 .md [href="#missedthepoint"]:hover{animation:missedthepoint 2.4s steps(23);animation-fill-mode:forwards}
+@keyframes hajimepout{from{background-position:0 -3497px}
+to{background-position:0 -1464px}}
+.md [href="#hajimepout"]{height:105px;width:191px;background:url(%%SoloSheet%%) -0px -3497px no-repeat}
+.md [href="#hajimepout"]:hover{animation:hajimepout 1.74s steps(19);animation-fill-mode:forwards}
 @keyframes nuidideverythingright{from{background-position:0 -5885px}
 to{background-position:0 -5243px}}
 .md [href="#nuidideverythingright"]{height:105px;width:191px;background:url(%%AnythingButPepsiSheet%%) -0px -5885px no-repeat}
@@ -1638,6 +1497,19 @@ to{background-position:0 -6741px}}
 to{background-position:0 -11128px}}
 .md [href="#slapbet"]{height:105px;width:191px;background:url(%%MountainDewSheet%%) -0px -11984px no-repeat}
 .md [href="#slapbet"]:hover{animation:slapbet .72s steps(8) infinite}
+@keyframes watchadoin{from{background-position:0 -10914px}
+to{background-position:0 -8774px}}
+.md [href="#watchadoin"]{height:105px;width:191px;background:url(%%GingerAleSheet%%) -0px -10914px no-repeat}
+.md [href="#watchadoin"]:hover{animation:watchadoin 2.1s steps(20) infinite}
+.wiki-page[class*="commentface"] table strong{display:block;text-align:center}
+@keyframes torrentialdownpour{from{background-position:0 -8667px}
+to{background-position:0 -3210px}}
+.md [href="#torrentialdownpour"]{height:105px;width:191px;background:url(%%GingerAleSheet%%) -0px -8667px no-repeat}
+.md [href="#torrentialdownpour"]:hover{animation:torrentialdownpour 3.64s steps(51)}
+@keyframes slightoverreaction{from{background-position:0 -13375px}
+to{background-position:0 -5136px}}
+.md [href="#slightoverreaction"]{height:105px;width:191px;background:url(%%DrPepperSheet%%) -0px -13375px no-repeat}
+.md [href="#slightoverreaction"]:hover{animation:slightoverreaction 6.24s steps(77) infinite}
 @keyframes prelenny{from{background-position:0 -7323px}
 to{background-position:0 -6313px}}
 .md [href="#prelenny"]{height:99px;width:191px;background:url(%%MotherSheet%%) -0px -7323px no-repeat}
@@ -1650,15 +1522,36 @@ to{background-position:0 -3317px}}
 to{background-position:0 -7424px}}
 .md [href="#mywaifumadeyouasandwich"]{height:105px;width:190px;background:url(%%MotherSheet%%) -0px -8708px no-repeat}
 .md [href="#mywaifumadeyouasandwich"]:hover{animation:mywaifumadeyouasandwich 1.3s steps(12);animation-fill-mode:forwards}
-@keyframes torrentialdownpour{from{background-position:0 -8667px}
-to{background-position:0 -3210px}}
-.md [href="#torrentialdownpour"]{height:105px;width:191px;background:url(%%GingerAleSheet%%) -0px -8667px no-repeat}
-.md [href="#torrentialdownpour"]:hover{animation:torrentialdownpour 3.64s steps(51)}
-@keyframes watchadoin{from{background-position:0 -10914px}
-to{background-position:0 -8774px}}
-.md [href="#watchadoin"]{height:105px;width:191px;background:url(%%GingerAleSheet%%) -0px -10914px no-repeat}
-.md [href="#watchadoin"]:hover{animation:watchadoin 2.1s steps(20) infinite}
-.wiki-page[class*="commentface"] table strong{display:block;text-align:center}
+@keyframes urbansmile{from{background-position:0 -11522px}
+to{background-position:0 -8954px}}
+.md [href="#urbansmile"]{height:105px;width:191px;background:url(%%SoloSheet%%) 0 -11522px no-repeat}
+.md [href="#urbansmile"]:hover{animation:urbansmile 1.46s steps(24);animation-fill-mode:forwards}
+@keyframes anko{from{background-position:0 -1498px}
+to{background-position:0 0}}
+.md [href="#anko"]{height:105px;width:191px;background:url(%%DrPepperSheet%%) -0px -1498px no-repeat}
+.md [href="#anko"]:hover{animation:anko 1.8s steps(14);animation-fill-mode:forwards}
+@keyframes hyoukawink{from{background-position:0 -1342px}
+to{background-position:0 0}}
+.md [href="#hyoukawink"]{height:120px;width:191px;background:url(%%SoloSheet%%) -0px -1342px no-repeat}
+.md [href="#hyoukawink"]:hover{animation:hyoukawink 1.8s steps(11);animation-fill-mode:forwards}
+@keyframes yousaidsomethingdumb{from{background-position:0 -8847px}
+to{background-position:0 -3604px}}
+.md [href="#yousaidsomethingdumb"]{height:105px;width:191px;background:url(%%SoloSheet%%) -0px -8847px no-repeat}
+.md [href="#yousaidsomethingdumb"]:hover{animation:yousaidsomethingdumb 2.5s steps(49);animation-fill-mode:forwards}
+@keyframes banjo{from{background-position:0 -5029px}
+to{background-position:0 -1605px}}
+.md [href="#banjo"]{height:105px;width:191px;background:url(%%DrPepperSheet%%) -0px -5029px no-repeat}
+.md [href="#banjo"]:hover{animation:banjo 1.44s steps(32);animation-fill-mode:forwards}
+@keyframes peasants{from{background-position:0 -13769px}
+to{background-position:0 -11629px}}
+.md [href="#peasants"]{height:105px;width:190px;background:url(%%SoloSheet%%) -0px -13769px no-repeat}
+.md [href="#peasants"]:hover{animation:peasants 1.2s steps(20);animation-fill-mode:forwards}
+@keyframes excitedyui{from{background-position:0 0}
+to{background-position:0 -1148px}}
+.md [href="#excitedyui"]{height:162px;width:122px;background:url(%%animatedsheet1%%) -0px 0 no-repeat}
+.md [href="#excitedyui"]:hover{animation:excitedyui .8s steps(7) infinite}
+
+/** Animated Set #2 **/
 @keyframes budgetsmile{from{background-position:0 -6634px}
 to{background-position:0 0}}
 .md [href="#budgetsmile"]{height:105px;width:190px;background:url(%%budgetsheet%%) -0px -6634px no-repeat}
@@ -1791,6 +1684,426 @@ to{background-position:0 -11396px}}
 to{background-position:0 -8400px}}
 .md [href="#niconicono"]{height:105px;width:190px;background:url(%%SurgeSheet%%) -0px -11289px no-repeat}
 .md [href="#niconicono"]:hover{animation:niconicono 2.07s steps(27);animation-fill-mode:forwards}
+
+/** Animated Set #3 **/
+@keyframes akkotears{from{background-position:0 -3300px}
+to{background-position:0 0}}
+.md [href="#akkotears"]{height:148px;width:150px;background:url(%%anim1%%) 0 -3300px no-repeat}
+.md [href="#akkotears"]:hover{animation:akkotears 1.44s steps(22) infinite}
+@keyframes aliens{from{background-position:0 -10618px}
+to{background-position:0 -9658px}}
+.md [href="#aliens"]{height:118px;width:150px;background:url(%%anim1%%) 0 -10618px no-repeat}
+.md [href="#aliens"]:hover{animation:aliens .5s steps(8) infinite}
+@keyframes angrypout{from{background-position:0 -4950px}
+to{background-position:0 -3450px}}
+.md [href="#angrypout"]{height:148px;width:150px;background:url(%%anim1%%) 0 -4950px no-repeat}
+.md [href="#angrypout"]:hover{animation:angrypout 1.0s steps(10);animation-fill-mode:forwards}
+@keyframes blankblink{from{background-position:0 -7200px}
+to{background-position:0 -5100px}}
+.md [href="#blankblink"]{height:138px;width:150px;background:url(%%anim1%%) 0 -7200px no-repeat}
+.md [href="#blankblink"]:hover{animation:blankblink 1.12s steps(15) infinite}
+@keyframes criticism{from{background-position:0 -6276px}
+to{background-position:0 -1684px}}
+.md [href="#criticism"]{height:111px;width:150px;background:url(%%anim3%%) 0 -6276px no-repeat}
+.md [href="#criticism"]:hover{animation:criticism 2.5s steps(41);animation-fill-mode:forwards}
+@keyframes emptyinside{from{background-position:0 -9536px}
+to{background-position:0 -7340px}}
+.md [href="#emptyinside"]{height:120px;width:150px;background:url(%%anim1%%) 0 -9536px no-repeat}
+.md [href="#emptyinside"]:hover{animation:emptyinside .76s steps(18);animation-fill-mode:forwards}
+@keyframes comfortfood{from{background-position:0 -10102px}
+to{background-position:0 -8744px}}
+.md [href="#comfortfood"]{height:95px;width:178px;background:url(%%anim2%%) 0 -10102px no-repeat}
+.md [href="#comfortfood"]:hover{animation:comfortfood 1.46s steps(14) infinite}
+@keyframes trynottocry{from{background-position:0 -4300px}
+to{background-position:0 -2400px}}
+.md [href="#trynottocry"]{height:98px;width:178px;background:url(%%anim6%%) 0 -4300px no-repeat}
+.md [href="#trynottocry"]:hover{animation:trynottocry 2s steps(19);animation-fill-mode:forwards}
+@keyframes dekuhype{from{background-position:0 -1232px}
+to{background-position:0 0}}
+.md [href="#dekuhype"]{height:110px;width:178px;background:url(%%anim2%%) 0 -1232px no-repeat}
+.md [href="#dekuhype"]:hover{animation:dekuhype .96s steps(11) infinite}
+@keyframes emiliaohdear{from{background-position:0 -1744px}
+to{background-position:0 -1344px}}
+.md [href="#emiliaohdear"]{height:98px;width:178px;background:url(%%anim2%%) 0 -1744px no-repeat}
+.md [href="#emiliaohdear"]:hover{animation:emiliaohdear .35s steps(4);animation-fill-mode:forwards}
+@keyframes hugbear{from{background-position:0 -4344px}
+to{background-position:0 -1844px}}
+.md [href="#hugbear"]{height:98px;width:178px;background:url(%%anim2%%) 0 -4344px no-repeat}
+.md [href="#hugbear"]:hover{animation:hugbear 1.25s steps(25);animation-fill-mode:forwards}
+@keyframes lolipolice{from{background-position:0 -4944px}
+to{background-position:0 -4444px}}
+.md [href="#lolipolice"]{height:98px;width:178px;background:url(%%anim2%%) 0 -4944px no-repeat}
+.md [href="#lolipolice"]:hover{animation:lolipolice .36s steps(5) infinite}
+@keyframes mashiroglare{from{background-position:0 -1600px}
+to{background-position:0 0}}
+.md [href="#mashiroglare"]{height:98px;width:178px;background:url(%%anim4%%) 0 -1600px no-repeat}
+.md [href="#mashiroglare"]:hover{animation:mashiroglare .68s steps(16);animation-fill-mode:forwards}
+@keyframes lwahorror{from{background-position:0 -6944px}
+to{background-position:0 -5044px}}
+.md [href="#lwahorror"]{height:98px;width:178px;background:url(%%anim2%%) 0 -6944px no-repeat}
+.md [href="#lwahorror"]:hover{animation:lwahorror 2.0s steps(19);animation-fill-mode:forwards}
+@keyframes lwahorror2{from{background-position:0 -8644px}
+to{background-position:0 -7044px}}
+.md [href="#lwahorror2"]{height:98px;width:178px;background:url(%%anim2%%) 0 -8644px no-repeat}
+.md [href="#lwahorror2"]:hover{animation:lwahorror2 1.7s steps(16);animation-fill-mode:forwards}
+@keyframes salt{from{background-position:0 -2800px}
+to{background-position:0 -1700px}}
+.md [href="#salt"]{height:98px;width:178px;background:url(%%anim4%%) 0 -2800px no-repeat}
+.md [href="#salt"]:hover{animation:salt .84s steps(11) infinite}
+@keyframes modabuse{from{background-position:0 -1176px}
+to{background-position:0 0}}
+.md [href="#modabuse"]{height:145px;width:150px;background:url(%%anim3%%) 0 -1176px no-repeat}
+.md [href="#modabuse"]:hover{animation:modabuse .8s steps(8) infinite}
+/** #hisocuck has no keyframe??? **/
+.md [href="#hisocuck"]{height:122px;width:150px;background:url(%%anim3%%) 0 -1447px no-repeat}
+.md [href="#hisocuck"]:hover{background:url(%%anim3%%) 0 -1323px no-repeat}
+@keyframes salutegeo{from{background-position:0 -4100px}
+to{background-position:0 -2900px}}
+.md [href="#salutegeo"]{height:98px;width:178px;background:url(%%anim4%%) 0 -4100px no-repeat}
+.md [href="#salutegeo"]:hover{animation:salutegeo 1.3s steps(12);animation-fill-mode:forwards}
+@keyframes shitposting{from{background-position:0 -6100px}
+to{background-position:0 -4200px}}
+.md [href="#shitposting"]{height:98px;width:178px;background:url(%%anim4%%) 0 -6100px no-repeat}
+.md [href="#shitposting"]:hover{animation:shitposting 2.6s steps(19) infinite}
+@keyframes squee{from{background-position:0 -7800px}
+to{background-position:0 -6200px}}
+.md [href="#squee"]{height:98px;width:178px;background:url(%%anim4%%) 0 -7800px no-repeat}
+.md [href="#squee"]:hover{animation:squee 1.7s steps(16);animation-fill-mode:forwards}
+@keyframes terror{from{background-position:0 -2300px}
+to{background-position:0 0}}
+.md [href="#terror"]{height:98px;width:178px;background:url(%%anim6%%) 0 -2300px no-repeat}
+.md [href="#terror"]:hover{animation:terror 2.4s steps(23);animation-fill-mode:forwards}
+@keyframes awe{from{background-position:0 -4900px}
+to{background-position:0 -2800px}}
+.md [href="#awe"]{height:98px;width:178px;background:url(%%anim5%%) 0 -4900px no-repeat}
+.md [href="#awe"]:hover{animation:awe 2.42s steps(21) infinite}
+@keyframes wow{from{background-position:0 -2700px}
+to{background-position:0 0}}
+.md [href="#wow"]{height:98px;width:178px;background:url(%%anim5%%) 0 -2700px no-repeat}
+.md [href="#wow"]:hover{animation:wow 1.68s steps(27);animation-fill-mode:forwards}
+@keyframes nyanpasu{from{background-position:0 -8162px}
+to{background-position:0 -4400px}}
+.md [href="#nyanpasu"]{height:169px;width:150px;background:url(%%anim6%%) 0 -8162px no-repeat}
+.md [href="#nyanpasu"]:hover{animation:nyanpasu 2.64s steps(22);animation-fill-mode:forwards}
+@keyframes wallpunch{from{background-position:0 -9197px}
+to{background-position:0 -8333px}}
+.md [href="#wallpunch"]{height:106px;width:150px;background:url(%%anim6%%) 0 -9197px no-repeat}
+.md [href="#wallpunch"]:hover{animation:wallpunch .9s steps(8);animation-fill-mode:forwards}
+@keyframes doggo{from{background-position:0 -1768px}
+to{background-position:0 0}}
+.md [href="#doggo"]{height:101px;width:183px;background:url(%%doggo%%) -0px -1768px no-repeat}
+.md [href="#doggo"]:hover{animation:doggo 2.07s steps(17);animation-fill-mode:forwards}
+@keyframes headpat{from{background-position:0 -9700px}
+to{background-position:0 0}}
+.md [href="#headpat"]{height:98px;width:235px;background:url(%%anim7%%) 0 -9700px no-repeat}
+.md [href="#headpat"]:hover{animation:headpat 7.76s steps(97) infinite}
+
+
+/** Spritesheet 1 **/
+.md [href="#gendo-pls"],
+.md [href="#k-on-hug"],
+.md [href="#lewd"],
+.md [href="#nanami-hug"],
+.md [href="#yui-crying"],
+.md [href="#ok"]
+{
+	background-image:url(%%spritesheet1%%)
+}
+.md [href="#gendo-pls"]{width:171px;height:114px;background-position:0 -520px}
+.md [href="#k-on-hug"]{width:180px;height:120px;background-position:0 -814px}
+.md [href="#lewd"]{width:100px;height:150px;background-position:0 -984px}
+.md [href="#nanami-hug"]{width:120px;height:150px;background-position:0 -1184px}
+.md [href="#yui-crying"]{width:80px;height:80px;background-position:0 -1644px}
+.md [href="#ok"]{width:100px;height:100px;background-position:-100px 0}
+
+
+/** Spritesheet 2 **/
+.md [href="#stare"],
+.md [href="#what"]
+{
+	background-image:url(%%spritesheet2%%)
+}
+.md [href="#stare"]{width:150px;height:100px;background-position:0 -780px}
+.md [href="#what"]{width:100px;height:80px;background-position:0 -1060px}
+
+
+/** Spritesheet 3 **/
+.md [href="#gununu"]{background-image:url(%%spritesheet3%%);display:inline-block;width:107px;height:80px;background-position:0 -780px}
+
+
+/** Spritesheet 4 **/
+.md [href="#facepalm"],
+.md [href="#nico-heart"],
+.md [href="#thumbs-up"],
+.md [href="#kukuku"]
+{
+	background-image:url(%%spritesheet4%%)
+}
+.md [href="#facepalm"]{width:80px;height:80px;background-position:0 0}
+.md [href="#nico-heart"]{width:100px;height:80px;background-position:0 -520px}
+.md [href="#thumbs-up"]{width:120px;height:100px;background-position:0 -1430px}
+.md [href="#kukuku"]{width:100px;height:150px;background-position:-170px -390px}
+
+
+/** Spritesheet 5 **/
+.md [href="#kotori"],
+.md [href="#araragi-1"],
+.md [href="#deadpan"],
+.md [href="#head-tilt"],
+.md [href="#manly-tears"],
+.md [href="#not-raining"],
+.md [href="#ohmygod"],
+.md [href="#shock"],
+.md [href="#heart-thumbs-up"],
+.md [href="#wow-really"]
+{
+	background-image:url(%%spritesheet5%%)
+}
+.md [href="#kotori"]{width:85px;height:89px;background-position:-215px -5px}
+.md [href="#araragi-1"]{width:100px;height:50px;background-position:-5px -95px}
+.md [href="#deadpan"]{width:80px;height:85px;background-position:-300px -155px}
+.md [href="#head-tilt"]{width:121px;height:100px;background-position:-312px -290px}
+.md [href="#manly-tears"]{width:150px;height:100px;background-position:-445px -5px}
+.md [href="#not-raining"]{width:146px;height:100px;background-position:-480px -115px}
+.md [href="#ohmygod"]{width:175px;height:100px;background-position:-443px -290px}
+.md [href="#shock"]{width:170px;height:100px;background-position:-115px -400px}
+.md [href="#heart-thumbs-up"]{width:79px;height:100px;background-position:-295px -400px}
+.md [href="#wow-really"]{width:80px;height:85px;background-position:-564px -400px}
+
+
+/** Static Spritesheet 1 **/
+.md [href="#badassmugi"],
+.md [href="#banjoisahellofadrug"],
+.md [href="#bearhug"],
+.md [href="#bearwithme"],
+.md [href="#biribiricat"],
+.md [href="#csikon"],
+.md [href="#elsieqq"],
+.md [href="#haruhiisnotamused"],
+.md [href="#hisokaclown"],
+.md [href="#hanasakueurgh"],
+.md [href="#jibrilaww"],
+.md [href="#jibrilfetish"],
+.md [href="#katoupls"],
+.md [href="#mechablush"],
+.md [href="#miiaembarassed"],
+.md [href="#misakiteehee"],
+.md [href="#misakiwink"],
+.md [href="#nononkek"],
+.md [href="#ohgodwhathaveidone"],
+.md [href="#smugpoint"],
+.md [href="#smugshinobu"],
+.md [href="#SPORTS"],
+.md [href="#whowouldathunkit"],
+.md [href="#yandereyuno"],
+.md [href="#cup2"],
+.md [href="#annoyedkirito"],
+.md [href="#bestiathumbsup"],
+.md [href="#flclawe"],
+.md [href="#crazedlaugh"],
+.md [href="#cup1"],
+.md [href="#gintamaspillage"],
+.md [href="#hunchedover"],
+.md [href="#hypeoverload"],
+.md [href="#infernocopu"],
+.md [href="#niatilt"],
+.md [href="#nosepick"],
+.md [href="#mug1"],
+.md [href="#mug3"]
+{
+	background-image:url(%%StaticSpriteSheet1%%);width:178px;height:98px
+}
+ele{color:#f00}
+.md [href="#badassmugi"]{background:0 -2922px}
+.md [href="#banjoisahellofadrug"]{background:0 -3022px}
+.md [href="#bearhug"]{background:0 -3122px}
+.md [href="#bearwithme"]{background:0 -3222px}
+.md [href="#biribiricat"]{background:0 -3322px}
+.md [href="#csikon"]{background:0 -3622px}
+.md [href="#elsieqq"]{background:0 -3922px}
+.md [href="#flclawe"]{height:133px!important;background:0 -841px}
+.md [href="#haruhiisnotamused"]{background:0 -4222px}
+.md [href="#hisokaclown"]{background:0 -4422px}
+.md [href="#hanasakueurgh"]{background:0 -4122px}
+.md [href="#jibrilaww"]{background:0 -4622px}
+.md [href="#jibrilfetish"]{background:0 -4722px}
+.md [href="#katoupls"]{background:0 -4922px}
+.md [href="#mechablush"]{background:0 -5222px}
+.md [href="#miiaembarassed"]{background:0 -5422px}
+.md [href="#misakiteehee"]{background:0 -5622px}
+.md [href="#misakiwink"]{background:0 -5722px}
+.md [href="#nononkek"]{background:0 -5822px}
+.md [href="#ohgodwhathaveidone"]{background:0 -6022px}
+.md [href="#smugpoint"]{background:0 -6622px}
+.md [href="#smugshinobu"]{background:0 -6722px}
+.md [href="#SPORTS"]{background:0 -6922px}
+.md [href="#whowouldathunkit"]{background:0 -7822px}
+.md [href="#yandereyuno"]{background:0 -8022px}
+.md [href="#cup2"]{background:0 -3722px}
+.md [href="#annoyedkirito"]{height:113px!important;background:0 -2472px}
+.md [href="#bestiathumbsup"]{height:133px!important;background:0 -706px}
+.md [href="#crazedlaugh"]{height:119px!important;background:0 -1879px}
+.md [href="#cup1"]{height:124px!important;background:0 -1508px}
+.md [href="#gintamaspillage"]{height:129px!important;background:0 -1377px}
+.md [href="#hunchedover"]{height:141px!important;background:0 -144px}
+.md [href="#hypeoverload"]{width:125px!important;height:150px!important;background:0 -8122px}
+.md [href="#infernocopu"]{width:125px!important;height:123px!important;background:0 -8274px}
+.md [href="#niatilt"]{height:114px!important;background:0 -2704px}
+.md [href="#nosepick"]{height:116px!important;background:0 -2119px}
+.md [href="#mug1"]{height:131px!important;background:0 -1111px}
+.md [href="#mug3"]{height:131px!important;background:0 -1244px}
+
+
+/** Static Spritesheet 2 **/
+.md [href="#akyuusqueel"],
+.md [href="#arakawascream"],
+.md [href="#asunanotamused"],
+.md [href="#barakamonnotcool"],
+.md [href="#bestiacheckyourprivilage"],
+.md [href="#chiyomad"],
+.md [href="#comewithmeifyouwanttobebestgirl"],
+.md [href="#crazyhatgirlexcited"],
+.md [href="#disbelief"],
+.md [href="#dontdometh"],
+.md [href="#duckhue"],
+.md [href="#embarassedisla"],
+.md [href="#gintamacrushed"],
+.md [href="#gintamasunlight"],
+.md [href="#gintamathispleasesme"],
+.md [href="#happypoi"],
+.md [href="#izananotthisshitagain"],
+.md [href="#katoupout"],
+.md [href="#nocomment"],
+.md [href="#kumikouninterested"],
+.md [href="#kyonfacepalm"],
+.md [href="#maidshock"],
+.md [href="#marikalewd"],
+.md [href="#mug2"],
+.md [href="#nichijouqq"],
+.md [href="#rengehype"],
+.md [href="#scaredmio"],
+.md [href="#sheerdisgust"],
+.md [href="#smugillya"],
+.md [href="#smuglancer"],
+.md [href="#thoughtful"],
+.md [href="#trollarcher"],
+.md [href="#uglycry"],
+.md [href="#vashheadscratch"],
+.md [href="#WRYYY"],
+.md [href="#yuruyuriapprove"],
+.md [href="#happydera"],
+.md [href="#holdme"],
+.md [href="#misakaheh"],
+.md [href="#ohnoudidnt"],
+.md [href="#teehee"],
+.md [href="#tiredfate"],
+.md [href="#chitogheh"]
+{
+	background:url(%%StaticSpriteSheet2%%);width:178px;height:98px
+}
+.md [href="#akyuusqueel"]{width:129px;height:121px;background-position:0 -8621px}
+.md [href="#arakawascream"]{width:143px;height:117px;background-position:0 -7733px}
+.md [href="#asunanotamused"]{width:125px;height:118px;background-position:0 -10136px}
+.md [href="#barakamonnotcool"]{background-position:0 -400px}
+.md [href="#bestiacheckyourprivilage"]{width:123px;height:106px;background-position:0 -10615px}
+.md [href="#chiyomad"]{background-position:0 -700px}
+.md [href="#comewithmeifyouwanttobebestgirl"]{background-position:0 -800px}
+.md [href="#crazyhatgirlexcited"]{background-position:0 -1000px}
+.md [href="#disbelief"]{width:125px;height:119px;background-position:0 -10015px}
+.md [href="#dontdometh"]{width:143px;height:96px;background-position:0 -8410px}
+.md [href="#duckhue"]{width:143px;height:122px;background-position:0 -7485px}
+.md [href="#embarassedisla"]{background-position:0 -1100px}
+.md [href="#gintamacrushed"]{background-position:0 -1600px}
+.md [href="#gintamasunlight"]{background-position:0 -2000px}
+.md [href="#gintamathispleasesme"]{width:143px;height:141px;background-position:0 -6403px}
+.md [href="#happypoi"]{width:143px;height:142px;background-position:0 -6259px}
+.md [href="#izananotthisshitagain"]{width:125px;height:135px;background-position:0 -9616px}
+.md [href="#katoupout"]{background-position:0 -2300px}
+.md [href="#nocomment"]{background-position:0 -2400px}
+.md [href="#kumikouninterested"]{width:125px;height:140px;background-position:0 -9336px}
+.md [href="#kyonfacepalm"]{background-position:0 -2500px}
+.md [href="#maidshock"]{width:107px;height:106px;background-position:0 -10978px}
+.md [href="#marikalewd"]{width:125px;height:157px;background-position:0 -8864px}
+.md [href="#mug2"]{width:143px;height:105px;background-position:0 -8198px}
+.md [href="#nichijouqq"]{width:123px;height:118px;background-position:0 -8744px}
+.md [href="#rengehype"]{background-position:0 -3000px}
+.md [href="#scaredmio"]{width:123px;height:154px;background-position:0 -10822px}
+.md [href="#sheerdisgust"]{width:143px;height:158px;background-position:0 -6097px}
+.md [href="#smugillya"]{width:142px;height:128px;background-position:0 -7228px}
+.md [href="#smuglancer"]{width:143px;height:122px;background-position:0 -7609px}
+.md [href="#thoughtful"]{width:143px;height:114px;background-position:0 -7852px}
+.md [href="#trollarcher"]{width:125px;height:154px;background-position:0 -9180px}
+.md [href="#uglycry"]{background-position:0 -4000px}
+.md [href="#vashheadscratch"]{width:143px;height:103px;background-position:0 -8305px}
+.md [href="#WRYYY"]{background-position:0 -4100px}
+.md [href="#yuruyuriapprove"]{background-position:0 -4400px}
+.md [href="#happydera"]{background-position:0 -4500px}
+.md [href="#holdme"]{background-position:0 -4600px}
+.md [href="#misakaheh"]{background-position:0 -4700px}
+.md [href="#ohnoudidnt"]{background-position:0 -4800px}
+.md [href="#teehee"]{width:155px;height:122px;background-position:0 -5408px}
+.md [href="#tiredfate"]{background-position:0 -5200px}
+.md [href="#chitogheh"]{background-position:0 0}
+
+
+/** Cream Soda Sheet 1 **/
+.md [href="#amurodealwithit"],
+.md [href="#antabaka"],
+.md [href="#badtaste"],
+.md [href="#brokenkokoro"],
+.md [href="#calmdown"],
+.md [href="#chinosmirk"],
+.md [href="#concealedexcitement"],
+.md [href="#cup3"],
+.md [href="#cup6"],
+.md [href="#didyouseriouslyjustsaythat"],
+.md [href="#displeasedasuka"],
+.md [href="#edneedsdis"],
+.md [href="#exciteutawarerumono"],
+.md [href="#faito"],
+.md [href="#forbiddenlove"],
+.md [href="#ginapproves"],
+.md [href="#goblet1"],
+.md [href="#happysaitama"],
+.md [href="#helmetgril"],
+.md [href="#howcouldyou"],
+.md [href="#igiveup"],
+.md [href="#ilovethiskindofshit"],
+.md [href="#juice1"],
+.md [href="#konosubawot"],
+.md [href="#konosubawot2"],
+.md [href="#kukuku2"],
+.md [href="#kumikolook"],
+.md [href="#kumikotears"],
+.md [href="#miyamoriunimpressed"],
+.md [href="#mug4"],
+.md [href="#mug5"],
+.md [href="#mug7"],
+.md [href="#noice"],
+.md [href="#notaccordingtokeikaku"],
+.md [href="#oooreally"],
+.md [href="#osomatsurage"],
+.md [href="#papithumbsup"],
+.md [href="#pleasetellmemore"],
+.md [href="#psh-mongrels"],
+.md [href="#rinkek"],
+.md [href="#saberawe"],
+.md [href="#saitamadeathstare"],
+.md [href="#salute"],
+.md [href="#schemingsaten"],
+.md [href="#shinjimug"],
+.md [href="#smugasuna"],
+.md [href="#spookyglasses"],
+.md [href="#tamakoapple"],
+.md [href="#tearsofabestgirl"],
+.md [href="#thisisfine"],
+.md [href="#uglycry"],
+.md [href="#whatisthisguydoing"],
+.md [href="#yuishrug"],
+.md [href="#yunosunglasses"]
+{
+	background-image:url(%%CreamSodaSheet%%);width:129px;height:121px
+}
 .md [href="#amurodealwithit"]{background:0 -323px}
 .md [href="#antabaka"]{background:0 -569px}
 .md [href="#badtaste"]{background:0 -815px}
@@ -1845,7 +2158,74 @@ to{background-position:0 -8400px}}
 .md [href="#whatisthisguydoing"]{background:0 -8318px}
 .md [href="#yuishrug"]{background:0 -8564px}
 .md [href="#yunosunglasses"]{width:105px!important;height:121px!important;background:0 -9281px}
-.md [href="#amurodealwithit"],.md [href="#antabaka"],.md [href="#badtaste"],.md [href="#brokenkokoro"],.md [href="#calmdown"],.md [href="#chinosmirk"],.md [href="#concealedexcitement"],.md [href="#cup3"],.md [href="#cup6"],.md [href="#didyouseriouslyjustsaythat"],.md [href="#displeasedasuka"],.md [href="#edneedsdis"],.md [href="#exciteutawarerumono"],.md [href="#faito"],.md [href="#forbiddenlove"],.md [href="#ginapproves"],.md [href="#goblet1"],.md [href="#happysaitama"],.md [href="#helmetgril"],.md [href="#howcouldyou"],.md [href="#igiveup"],.md [href="#ilovethiskindofshit"],.md [href="#juice1"],.md [href="#konosubawot"],.md [href="#konosubawot2"],.md [href="#kukuku2"],.md [href="#kumikolook"],.md [href="#kumikotears"],.md [href="#miyamoriunimpressed"],.md [href="#mug4"],.md [href="#mug5"],.md [href="#mug7"],.md [href="#noice"],.md [href="#notaccordingtokeikaku"],.md [href="#oooreally"],.md [href="#osomatsurage"],.md [href="#papithumbsup"],.md [href="#pleasetellmemore"],.md [href="#psh-mongrels"],.md [href="#rinkek"],.md [href="#saberawe"],.md [href="#saitamadeathstare"],.md [href="#salute"],.md [href="#schemingsaten"],.md [href="#shinjimug"],.md [href="#smugasuna"],.md [href="#spookyglasses"],.md [href="#tamakoapple"],.md [href="#tearsofabestgirl"],.md [href="#thisisfine"],.md [href="#uglycry"],.md [href="#whatisthisguydoing"],.md [href="#yuishrug"],.md [href="#yunosunglasses"]{background-image:url(%%CreamSodaSheet%%);width:129px;height:121px}
+
+
+/** Root Beer **/
+.md [href="#annoyedmayaka"],
+.md [href="#annoyedsaber"],
+.md [href="#banhammer"],
+.md [href="#bitchplease"],
+.md [href="#cheekygahara"],
+.md [href="#crumblingdespair"],
+.md [href="#cup4"],
+.md [href="#cup5"],
+.md [href="#delicioustears"],
+.md [href="#donewiththisshit"],
+.md [href="#firstthinginthemorning"],
+.md [href="#fuckyou"],
+.md [href="#giveitback"],
+.md [href="#glasses-push"],
+.md [href="#hackadollthumbsup"],
+.md [href="#healthypasstimes"],
+.md [href="#hououinseesit"],
+.md [href="#justasplanned"],
+.md [href="#kaorusmile"],
+.md [href="#keikaku"],
+.md [href="#killuadisgust"],
+.md [href="#konodioda"],
+.md [href="#kotourashock"],
+.md [href="#kurokokek"],
+.md [href="#labmembernumber009"],
+.md [href="#lovenectar"],
+.md [href="#meguminthumbsup"],
+.md [href="#minoridenied"],
+.md [href="#mitsukishock"],
+.md [href="#mug6"],
+.md [href="#overwhelmed"],
+.md [href="#peace"],
+.md [href="#plebgetawayfromme"],
+.md [href="#poltears"],
+.md [href="#quality"],
+.md [href="#recoil"],
+.md [href="#saehug"],
+.md [href="#saesmile"],
+.md [href="#sciencebringspeopletogether"],
+.md [href="#schwing"],
+.md [href="#shatteredsaten"],
+.md [href="#shirayukidetermined"],
+.md [href="#shirayukidizzyblush"],
+.md [href="#shirayukidrunk"],
+.md [href="#shirayukieavesdrop"],
+.md [href="#shirayukifuckinreally"],
+.md [href="#shirayukismile"],
+.md [href="#smughaikyuu"],
+.md [href="#smugobi"],
+.md [href="#takaradasalute"],
+.md [href="#takasakiapproves"],
+.md [href="#thinkingtoohard"],
+.md [href="#TOMODA"],
+.md [href="#toradorable"],
+.md [href="#toradorasalute"],
+.md [href="#triggeredkillua"],
+.md [href="#trollnui"],
+.md [href="#utahapraises"],
+.md [href="#waah"],
+.md [href="#watashihasdeclined"],
+.md [href="#watashiworried"],
+.md [href="#whatamireading"]
+{
+	background-image:url(%%RootBeerSheet%%);width:178px;height:98px
+}
 .md [href="#annoyedmayaka"]{background:0 0}
 .md [href="#annoyedsaber"]{background:0 -100px}
 .md [href="#banhammer"]{background:0 -200px}
@@ -1908,7 +2288,19 @@ to{background-position:0 -8400px}}
 .md [href="#watashihasdeclined"]{background:0 -8000px}
 .md [href="#watashiworried"]{background:0 -8100px}
 .md [href="#whatamireading"]{background:0 -8200px}
-.md [href="#annoyedmayaka"],.md [href="#annoyedsaber"],.md [href="#banhammer"],.md [href="#bitchplease"],.md [href="#cheekygahara"],.md [href="#crumblingdespair"],.md [href="#cup4"],.md [href="#cup5"],.md [href="#delicioustears"],.md [href="#donewiththisshit"],.md [href="#firstthinginthemorning"],.md [href="#fuckyou"],.md [href="#giveitback"],.md [href="#glasses-push"],.md [href="#hackadollthumbsup"],.md [href="#healthypasstimes"],.md [href="#hououinseesit"],.md [href="#justasplanned"],.md [href="#kaorusmile"],.md [href="#keikaku"],.md [href="#killuadisgust"],.md [href="#konodioda"],.md [href="#kotourashock"],.md [href="#kurokokek"],.md [href="#labmembernumber009"],.md [href="#lovenectar"],.md [href="#meguminthumbsup"],.md [href="#minoridenied"],.md [href="#mitsukishock"],.md [href="#mug6"],.md [href="#overwhelmed"],.md [href="#peace"],.md [href="#plebgetawayfromme"],.md [href="#poltears"],.md [href="#quality"],.md [href="#recoil"],.md [href="#saehug"],.md [href="#saesmile"],.md [href="#sciencebringspeopletogether"],.md [href="#schwing"],.md [href="#shatteredsaten"],.md [href="#shirayukidetermined"],.md [href="#shirayukidizzyblush"],.md [href="#shirayukidrunk"],.md [href="#shirayukieavesdrop"],.md [href="#shirayukifuckinreally"],.md [href="#shirayukismile"],.md [href="#smughaikyuu"],.md [href="#smugobi"],.md [href="#takaradasalute"],.md [href="#takasakiapproves"],.md [href="#thinkingtoohard"],.md [href="#TOMODA"],.md [href="#toradorable"],.md [href="#toradorasalute"],.md [href="#triggeredkillua"],.md [href="#trollnui"],.md [href="#utahapraises"],.md [href="#waah"],.md [href="#watashihasdeclined"],.md [href="#watashiworried"],.md [href="#whatamireading"]{background-image:url(%%RootBeerSheet%%);width:178px;height:98px}
+
+
+/** Lenin Sheet 2 **/
+.md [href="#konosubot"],
+.md [href="#lewdbot"],
+.md [href="#hardtruthbot"],
+.md [href="#blushubot"],
+.md [href="#yanderebot"],
+.md [href="#bot-chan"],
+.md [href="#heartbot"]
+{
+	background-image:url(%%leninadesheet2%%)
+}
 .md [href="#konosubot"]{width:128px;height:151px;background:-166px -457px}
 .md [href="#lewdbot"]{width:151px;height:148px;background:0 -5px}
 .md [href="#hardtruthbot"]{width:151px;height:148px;background:0 -157px}
@@ -1916,11 +2308,48 @@ to{background-position:0 -8400px}}
 .md [href="#yanderebot"]{width:128px;height:148px;background:0 -461px}
 .md [href="#bot-chan"]{width:120px;height:148px;background:-153px -5px}
 .md [href="#heartbot"]{width:113px;height:148px;background:-160px -157px}
-.md [href="#konosubot"],.md [href="#lewdbot"],.md [href="#hardtruthbot"],.md [href="#blushubot"],.md [href="#yanderebot"],.md [href="#bot-chan"],.md [href="#heartbot"]{background-image:url(%%leninadesheet2%%)}
-@keyframes doggo{from{background-position:0 -1768px}
-to{background-position:0 0}}
-.md [href="#doggo"]{height:101px;width:183px;background:url(%%doggo%%) -0px -1768px no-repeat}
-.md [href="#doggo"]:hover{animation:doggo 2.07s steps(17);animation-fill-mode:forwards}
+
+
+/** STAT 1 **/
+.md [href="#adminsdidwhat"],
+.md [href="#airfist"],
+.md [href="#arresteddevelopment"],
+.md [href="#comfy"],
+.md [href="#saikikek"],
+.md [href="#cooresto"],
+.md [href="#ero"],
+.md [href="#everythingisfine"],
+.md [href="#frockychou"],
+.md [href="#fujostare"],
+.md [href="#gabdisgust"],
+.md [href="#happykaoru"],
+.md [href="#KUSOTTARE"],
+.md [href="#mmmmyrgh"],
+.md [href="#naziloli"],
+.md [href="#mangaka"],
+.md [href="#ohfuck"],
+.md [href="#ohshit"],
+.md [href="#ok_hand"],
+.md [href="#peacepeace"],
+.md [href="#protest"],
+.md [href="#ptsd"],
+.md [href="#sadholo"],
+.md [href="#shh"],
+.md [href="#shhbabe"],
+.md [href="#sleepingcutie"],
+.md [href="#whatdidijustread"],
+.md [href="#wideeyed"],
+.md [href="#nottodisushittoagen"],
+.md [href="#megubeer"],
+.md [href="#instillfear"],
+.md [href="#rec"],
+.md [href="#sweating"],
+.md [href="#teekyuuhype"],
+.md [href="#whisperwhisper"],
+.md [href="#getout"]
+{
+	background-image:url(%%stat1%%);width:178px;height:100px
+}
 .md [href="#adminsdidwhat"]{background:-0px -845px}
 .md [href="#airfist"]{background:-0px -945px}
 .md [href="#arresteddevelopment"]{background:-0px -1045px}
@@ -1957,7 +2386,72 @@ to{background-position:0 0}}
 .md [href="#teekyuuhype"]{background:-0px -224px;height:107px!important}
 .md [href="#whisperwhisper"]{background:-0px -116px;height:108px!important}
 .md [href="#getout"]{background:-0px -0px;height:116px!important}
-.md [href="#adminsdidwhat"],.md [href="#airfist"],.md [href="#arresteddevelopment"],.md [href="#comfy"],.md [href="#saikikek"],.md [href="#cooresto"],.md [href="#ero"],.md [href="#everythingisfine"],.md [href="#frockychou"],.md [href="#fujostare"],.md [href="#gabdisgust"],.md [href="#happykaoru"],.md [href="#KUSOTTARE"],.md [href="#mmmmyrgh"],.md [href="#naziloli"],.md [href="#mangaka"],.md [href="#ohfuck"],.md [href="#ohshit"],.md [href="#ok_hand"],.md [href="#peacepeace"],.md [href="#protest"],.md [href="#ptsd"],.md [href="#sadholo"],.md [href="#shh"],.md [href="#shhbabe"],.md [href="#sleepingcutie"],.md [href="#whatdidijustread"],.md [href="#wideeyed"],.md [href="#nottodisushittoagen"],.md [href="#megubeer"],.md [href="#instillfear"],.md [href="#rec"],.md [href="#sweating"],.md [href="#teekyuuhype"],.md [href="#whisperwhisper"],.md [href="#getout"]{background-image:url(%%stat1%%);width:178px;height:100px}
+
+
+/** STAT 2**/
+.md [href="#cup8"],
+.md [href="#kanyehidouyo"],
+.md [href="#konosubawot3"],
+.md [href="#makicry"],
+.md [href="#nicoisdone"],
+.md [href="#dubs"],
+.md [href="#mug10"],
+.md [href="#cateyes"],
+.md [href="#ohdear"],
+.md [href="#sideeyes"],
+.md [href="#loliwave"],
+.md [href="#towel"],
+.md [href="#fingertwirl"],
+.md [href="#mug9"],
+.md [href="#hellopolice"],
+.md [href="#eheheh"],
+.md [href="#girlishploy"],
+.md [href="#niconoo"],
+.md [href="#kms"],
+.md [href="#morethanonewaifu"],
+.md [href="#annoyedkiki"],
+.md [href="#usamiwink"],
+.md [href="#cup9"],
+.md [href="#smugrose"],
+.md [href="#lewdgyaru"],
+.md [href="#uwaa"],
+.md [href="#fujoship"],
+.md [href="#judgesucy"],
+.md [href="#selfcontrol"],
+.md [href="#taigaheadache"],
+.md [href="#killitwithfire"],
+.md [href="#datass"],
+.md [href="#surprisedhifumi"],
+.md [href="#nerr"],
+.md [href="#cantbehelped"],
+.md [href="#mindblank"],
+.md [href="#happyrem"],
+.md [href="#modsalute"],
+.md [href="#feelingloved"],
+.md [href="#assman"],
+.md [href="#zetsuboushta"],
+.md [href="#nicoheart"],
+.md [href="#eyythisguy"],
+.md [href="#loli_ok"],
+.md [href="#tomato"],
+.md [href="#nichijouthumbs"],
+.md [href="#biiru"],
+.md [href="#urarahype"],
+.md [href="#illyastare"],
+.md [href="#mug8"],
+.md [href="#konhug"],
+.md [href="#megushock"],
+.md [href="#dejected"],
+.md [href="#etotamadunno"],
+.md [href="#sowwy"],
+.md [href="#blindinglight"],
+.md [href="#cup7"],
+.md [href="#lifeishard"],
+.md [href="#nosenpai"],
+.md [href="#kannathumbs"]
+{
+	background-image:url(%%stat2%%);width:150px;height:116px
+}
 .md [href="#annoyedkiki"]{background:-0px -4989px;height:110px!important}
 .md [href="#assman"]{background:-0px -2715px;height:128px!important}
 .md [href="#biiru"]{background:-0px -1909px;height:138px!important}
@@ -2018,110 +2512,3 @@ to{background-position:0 0}}
 .md [href="#usamiwink"]{background:-0px -5099px;height:110px!important}
 .md [href="#uwaa"]{background:-0px -4542px;height:113px!important}
 .md [href="#zetsuboushta"]{background:-0px -2843px;height:128px!important}
-.md [href="#cup8"],.md [href="#kanyehidouyo"],.md [href="#konosubawot3"],.md [href="#makicry"],.md [href="#nicoisdone"],.md [href="#dubs"],.md [href="#mug10"],.md [href="#cateyes"],.md [href="#ohdear"],.md [href="#sideeyes"],.md [href="#loliwave"],.md [href="#towel"],.md [href="#fingertwirl"],.md [href="#mug9"],.md [href="#hellopolice"],.md [href="#eheheh"],.md [href="#girlishploy"],.md [href="#niconoo"],.md [href="#kms"],.md [href="#morethanonewaifu"],.md [href="#annoyedkiki"],.md [href="#usamiwink"],.md [href="#cup9"],.md [href="#smugrose"],.md [href="#lewdgyaru"],.md [href="#uwaa"],.md [href="#fujoship"],.md [href="#judgesucy"],.md [href="#selfcontrol"],.md [href="#taigaheadache"],.md [href="#killitwithfire"],.md [href="#datass"],.md [href="#surprisedhifumi"],.md [href="#nerr"],.md [href="#cantbehelped"],.md [href="#mindblank"],.md [href="#happyrem"],.md [href="#modsalute"],.md [href="#feelingloved"],.md [href="#assman"],.md [href="#zetsuboushta"],.md [href="#nicoheart"],.md [href="#eyythisguy"],.md [href="#loli_ok"],.md [href="#tomato"],.md [href="#nichijouthumbs"],.md [href="#biiru"],.md [href="#urarahype"],.md [href="#illyastare"],.md [href="#mug8"],.md [href="#konhug"],.md [href="#megushock"],.md [href="#dejected"],.md [href="#etotamadunno"],.md [href="#sowwy"],.md [href="#blindinglight"],.md [href="#cup7"],.md [href="#lifeishard"],.md [href="#nosenpai"],.md [href="#kannathumbs"]{background-image:url(%%stat2%%);width:150px;height:116px}
-@keyframes akkotears{from{background-position:0 -3300px}
-to{background-position:0 0}}
-.md [href="#akkotears"]{height:148px;width:150px;background:url(%%anim1%%) 0 -3300px no-repeat}
-.md [href="#akkotears"]:hover{animation:akkotears 1.44s steps(22) infinite}
-@keyframes aliens{from{background-position:0 -10618px}
-to{background-position:0 -9658px}}
-.md [href="#aliens"]{height:118px;width:150px;background:url(%%anim1%%) 0 -10618px no-repeat}
-.md [href="#aliens"]:hover{animation:aliens .5s steps(8) infinite}
-@keyframes angrypout{from{background-position:0 -4950px}
-to{background-position:0 -3450px}}
-.md [href="#angrypout"]{height:148px;width:150px;background:url(%%anim1%%) 0 -4950px no-repeat}
-.md [href="#angrypout"]:hover{animation:angrypout 1.0s steps(10);animation-fill-mode:forwards}
-@keyframes blankblink{from{background-position:0 -7200px}
-to{background-position:0 -5100px}}
-.md [href="#blankblink"]{height:138px;width:150px;background:url(%%anim1%%) 0 -7200px no-repeat}
-.md [href="#blankblink"]:hover{animation:blankblink 1.12s steps(15) infinite}
-@keyframes emptyinside{from{background-position:0 -9536px}
-to{background-position:0 -7340px}}
-.md [href="#emptyinside"]{height:120px;width:150px;background:url(%%anim1%%) 0 -9536px no-repeat}
-.md [href="#emptyinside"]:hover{animation:emptyinside .76s steps(18);animation-fill-mode:forwards}
-@keyframes comfortfood{from{background-position:0 -10102px}
-to{background-position:0 -8744px}}
-.md [href="#comfortfood"]{height:95px;width:178px;background:url(%%anim2%%) 0 -10102px no-repeat}
-.md [href="#comfortfood"]:hover{animation:comfortfood 1.46s steps(14) infinite}
-@keyframes dekuhype{from{background-position:0 -1232px}
-to{background-position:0 0}}
-.md [href="#dekuhype"]{height:110px;width:178px;background:url(%%anim2%%) 0 -1232px no-repeat}
-.md [href="#dekuhype"]:hover{animation:dekuhype .96s steps(11) infinite}
-@keyframes emiliaohdear{from{background-position:0 -1744px}
-to{background-position:0 -1344px}}
-.md [href="#emiliaohdear"]{height:98px;width:178px;background:url(%%anim2%%) 0 -1744px no-repeat}
-.md [href="#emiliaohdear"]:hover{animation:emiliaohdear .35s steps(4);animation-fill-mode:forwards}
-@keyframes hugbear{from{background-position:0 -4344px}
-to{background-position:0 -1844px}}
-.md [href="#hugbear"]{height:98px;width:178px;background:url(%%anim2%%) 0 -4344px no-repeat}
-.md [href="#hugbear"]:hover{animation:hugbear 1.25s steps(25);animation-fill-mode:forwards}
-@keyframes lolipolice{from{background-position:0 -4944px}
-to{background-position:0 -4444px}}
-.md [href="#lolipolice"]{height:98px;width:178px;background:url(%%anim2%%) 0 -4944px no-repeat}
-.md [href="#lolipolice"]:hover{animation:lolipolice .36s steps(5) infinite}
-@keyframes lwahorror{from{background-position:0 -6944px}
-to{background-position:0 -5044px}}
-.md [href="#lwahorror"]{height:98px;width:178px;background:url(%%anim2%%) 0 -6944px no-repeat}
-.md [href="#lwahorror"]:hover{animation:lwahorror 2.0s steps(19);animation-fill-mode:forwards}
-@keyframes lwahorror2{from{background-position:0 -8644px}
-to{background-position:0 -7044px}}
-.md [href="#lwahorror2"]{height:98px;width:178px;background:url(%%anim2%%) 0 -8644px no-repeat}
-.md [href="#lwahorror2"]:hover{animation:lwahorror2 1.7s steps(16);animation-fill-mode:forwards}
-@keyframes criticism{from{background-position:0 -6276px}
-to{background-position:0 -1684px}}
-.md [href="#criticism"]{height:111px;width:150px;background:url(%%anim3%%) 0 -6276px no-repeat}
-.md [href="#criticism"]:hover{animation:criticism 2.5s steps(41);animation-fill-mode:forwards}
-@keyframes modabuse{from{background-position:0 -1176px}
-to{background-position:0 0}}
-.md [href="#modabuse"]{height:145px;width:150px;background:url(%%anim3%%) 0 -1176px no-repeat}
-.md [href="#modabuse"]:hover{animation:modabuse .8s steps(8) infinite}
-.md [href="#hisocuck"]{height:122px;width:150px;background:url(%%anim3%%) 0 -1447px no-repeat}
-.md [href="#hisocuck"]:hover{background:url(%%anim3%%) 0 -1323px no-repeat}
-@keyframes mashiroglare{from{background-position:0 -1600px}
-to{background-position:0 0}}
-.md [href="#mashiroglare"]{height:98px;width:178px;background:url(%%anim4%%) 0 -1600px no-repeat}
-.md [href="#mashiroglare"]:hover{animation:mashiroglare .68s steps(16);animation-fill-mode:forwards}
-@keyframes salt{from{background-position:0 -2800px}
-to{background-position:0 -1700px}}
-.md [href="#salt"]{height:98px;width:178px;background:url(%%anim4%%) 0 -2800px no-repeat}
-.md [href="#salt"]:hover{animation:salt .84s steps(11) infinite}
-@keyframes salutegeo{from{background-position:0 -4100px}
-to{background-position:0 -2900px}}
-.md [href="#salutegeo"]{height:98px;width:178px;background:url(%%anim4%%) 0 -4100px no-repeat}
-.md [href="#salutegeo"]:hover{animation:salutegeo 1.3s steps(12);animation-fill-mode:forwards}
-@keyframes shitposting{from{background-position:0 -6100px}
-to{background-position:0 -4200px}}
-.md [href="#shitposting"]{height:98px;width:178px;background:url(%%anim4%%) 0 -6100px no-repeat}
-.md [href="#shitposting"]:hover{animation:shitposting 2.6s steps(19) infinite}
-@keyframes squee{from{background-position:0 -7800px}
-to{background-position:0 -6200px}}
-.md [href="#squee"]{height:98px;width:178px;background:url(%%anim4%%) 0 -7800px no-repeat}
-.md [href="#squee"]:hover{animation:squee 1.7s steps(16);animation-fill-mode:forwards}
-@keyframes wow{from{background-position:0 -2700px}
-to{background-position:0 0}}
-.md [href="#wow"]{height:98px;width:178px;background:url(%%anim5%%) 0 -2700px no-repeat}
-.md [href="#wow"]:hover{animation:wow 1.68s steps(27);animation-fill-mode:forwards}
-@keyframes awe{from{background-position:0 -4900px}
-to{background-position:0 -2800px}}
-.md [href="#awe"]{height:98px;width:178px;background:url(%%anim5%%) 0 -4900px no-repeat}
-.md [href="#awe"]:hover{animation:awe 2.42s steps(21) infinite}
-@keyframes nyanpasu{from{background-position:0 -8162px}
-to{background-position:0 -4400px}}
-.md [href="#nyanpasu"]{height:169px;width:150px;background:url(%%anim6%%) 0 -8162px no-repeat}
-.md [href="#nyanpasu"]:hover{animation:nyanpasu 2.64s steps(22);animation-fill-mode:forwards}
-@keyframes terror{from{background-position:0 -2300px}
-to{background-position:0 0}}
-.md [href="#terror"]{height:98px;width:178px;background:url(%%anim6%%) 0 -2300px no-repeat}
-.md [href="#terror"]:hover{animation:terror 2.4s steps(23);animation-fill-mode:forwards}
-@keyframes trynottocry{from{background-position:0 -4300px}
-to{background-position:0 -2400px}}
-.md [href="#trynottocry"]{height:98px;width:178px;background:url(%%anim6%%) 0 -4300px no-repeat}
-.md [href="#trynottocry"]:hover{animation:trynottocry 2s steps(19);animation-fill-mode:forwards}
-@keyframes wallpunch{from{background-position:0 -9197px}
-to{background-position:0 -8333px}}
-.md [href="#wallpunch"]{height:106px;width:150px;background:url(%%anim6%%) 0 -9197px no-repeat}
-.md [href="#wallpunch"]:hover{animation:wallpunch .9s steps(8);animation-fill-mode:forwards}
-@keyframes headpat{from{background-position:0 -9700px}
-to{background-position:0 0}}
-.md [href="#headpat"]{height:98px;width:235px;background:url(%%anim7%%) 0 -9700px no-repeat}
-.md [href="#headpat"]:hover{animation:headpat 7.76s steps(97) infinite}


### PR DESCRIPTION
Animated comment faces are now grouped by the same "sets" (and same order) as the wiki page. Static comment faces can't be grouped by sets easily as the spritesheets don't match the sets. 

Also broke the static sheet long lines of spritesheet reference into multi-line property assignments. The horizontal scroll wheel thanks you.