### PR TITLE
add exception for RES gear icon

### DIFF
--- a/src/_commentfaces.scss
+++ b/src/_commentfaces.scss
@@ -62,6 +62,7 @@
 .md [href="#"], // Empty link
 .md [href^="#!"], // Toolbox links
 .md [href^="#res:"], // RES links
+.md [href^="#gear"], // RES gear icon
 .md [href^="#/"], // Empty link (for markdown)
 .md [href$="#/"], // utm version of the above
 .md [href^="#?"], // ?


### PR DESCRIPTION
#gear is a part of the RES console share link. It shows up as a broken comment face.

[example](https://www.reddit.com/r/anime/comments/bsa48t/c/ep9d7zg/) and [imgur pic](https://i.imgur.com/dRRW0ye.png)

(note: I have no idea what I'm doing, please double check that I'm actually doing this right)