### PR TITLE
Remove fish comment face

### DIFF
--- a/src/_commentfaces-static.scss
+++ b/src/_commentfaces-static.scss
@@ -30,7 +30,6 @@ $static-comment-faces: (
 				"everythingisfine": ("height": 100, "width": 178, "position": 4972),
 				"facepalm2": ("height": 100, "width": 178, "position": 5150),
 				"fightme": ("height": 100, "width": 178, "position": 5328),
-				"fish": ("height": 100, "width": 178, "position": 5506),
 				"fujostare": ("height": 100, "width": 178, "position": 5684),
 				"gabdisgust": ("height": 100, "width": 178, "position": 5862),
 				"gasp": ("height": 100, "width": 178, "position": 6040),


### PR DESCRIPTION
This PR only removes the face from the stylesheet. The image is still present elsewhere and will need to be removed later when I have time.