### PR TITLE
Better color consistency

### DIFF
--- a/_banner.scss
+++ b/_banner.scss
@@ -1,0 +1,4 @@
+// Custom banners get full background control through these variables.
+
+$header-background: url("images/header.png") center left/auto 100% #213553 no-repeat;
+$header-background-nightmode: $header-background;

--- a/main.scss
+++ b/main.scss
@@ -12,7 +12,8 @@
 
 // Customizations
 @import "subcount"; // Contains the sidebar subscriber/online user phrases
-@import "flairs"; // User CSS flair texts, etc. (needs to be before main theme
+@import "flairs"; // User CSS flair texts, etc. (needs to be before main theme)
+@import "banner"; // Custom banner images for special events
 
 // Main theme style
 @import "src/everything"; // Everything that isn't somewhere else yet

--- a/src/_everything.scss
+++ b/src/_everything.scss
@@ -319,7 +319,7 @@ span.multi-count {margin: 0!important}
 .morelink:hover a {
 	color: $text-on-secondary-color;
 	background: $sidebar-button-secondary-color;
-	box-shadow: 0 5px 10px rgba(0,0,0,0.2)
+	box-shadow: 0 5px 10px $primary-secondary-shadow;
 }
 .ad300x250,.sponsor-300-250 {border-radius: 5px}
 .side::after {
@@ -583,7 +583,7 @@ body #progressIndicator {
 }
 .submit-page ul.formtab .selected a {
 	top: -2px;
-	box-shadow: 0 5px 10px rgba(0,0,0,0.2);
+	box-shadow: 0 5px 10px $primary-secondary-shadow;
 	font-size: 18px
 }
 .submit-page .roundfield {
@@ -749,7 +749,7 @@ body #progressIndicator {
 }
 .res-nightmode #header .tabmenu .selected a::after {
 	background: #2f2f2f;
-	box-shadow: inset 2px 2px 2px -1px rgba(0,0,0,0.2), 1px 1px 1px #2f2f2f
+	box-shadow: inset 2px 2px 2px -1px $primary-secondary-shadow, 1px 1px 1px #2f2f2f
 }
 .res-nightmode.res #header {background-color: #445f7e}
 .res-nightmode #header-bottom-left {box-shadow: inset 0 -35px #2b4665}

--- a/src/_everything.scss
+++ b/src/_everything.scss
@@ -739,23 +739,16 @@ body #progressIndicator {
 .res-nightmode .side a.helplink,
 .res-nightmode .side .md h1 a,
 .res-nightmode .sidecontentbox .title .collapse-button {
-	background: #2b4665!important;
+	background: $secondary-color-nightmode !important;
 	color: inherit
 }
-.res-nightmode .wiki-page .pageactions .wikiaction-current {background: #2b4665!important}
+.res-nightmode .wiki-page .pageactions .wikiaction-current {background: $secondary-color-nightmode!important}
 .res-nightmode .morelink a {
 	background: #445f7e;
 	color: #FFF!important
 }
-.res-nightmode #header .tabmenu .selected a::after {
-	background: #2f2f2f;
-	box-shadow: inset 2px 2px 2px -1px $primary-secondary-shadow, 1px 1px 1px #2f2f2f
-}
-.res-nightmode.res #header {background-color: #445f7e}
-.res-nightmode #header-bottom-left {box-shadow: inset 0 -35px #2b4665}
-.res-nightmode.res #sr-header-area {background-color: #2b4665}
 .res-nightmode .morelink a:hover,
-.res-nightmode .morelink a::after {background-color: #2b4665}
+.res-nightmode .morelink a::after {background-color: $secondary-color-nightmode}
 .res-nightmode .wiki-page>.content>span {background-color: #445f7e}
 .res-nightmode .content .link {border-color: #0f0f0f} /* bulky selector to override weird report res style */
 .res-nightmode .link.RES-keyNav-activeThing {background: #373737}

--- a/src/_everything.scss
+++ b/src/_everything.scss
@@ -729,10 +729,10 @@ body #progressIndicator {
 .res-nightmode .side .redditname,
 .res-nightmode .sidecontentbox .title,
 .res-nightmode .side .md-container .md h1,
-.res-nightmode .sidecontentbox .content {background-color: #445f7e !important}
+.res-nightmode .sidecontentbox .content {background-color: $primary-color-nightmode !important}
 .res-nightmode .sidecontentbox .content {
 	background: #2f2f2f !important;
-	box-shadow: 0 -5px #445f7e;
+	box-shadow: 0 -5px $primary-color-nightmode;
 	border-color: #0f0f0f !important;
 }
 .res-nightmode .subscribe-button .option,
@@ -744,19 +744,19 @@ body #progressIndicator {
 }
 .res-nightmode .wiki-page .pageactions .wikiaction-current {background: $secondary-color-nightmode!important}
 .res-nightmode .morelink a {
-	background: #445f7e;
+	background: $primary-color-nightmode;
 	color: #FFF!important
 }
 .res-nightmode .morelink a:hover,
 .res-nightmode .morelink a::after {background-color: $secondary-color-nightmode}
-.res-nightmode .wiki-page>.content>span {background-color: #445f7e}
+.res-nightmode .wiki-page>.content>span {background-color: $primary-color-nightmode}
 .res-nightmode .content .link {border-color: #0f0f0f} /* bulky selector to override weird report res style */
 .res-nightmode .link.RES-keyNav-activeThing {background: #373737}
 .res-nightmode .submit-page {background: #1f1f1f!important}
 .res-nightmode .submit-page>.content,
 .res-nightmode .submit-page .content .content {background-color: transparent!important}
 .res-nightmode .tabmenu.formtab a {background-color: #2f2f2f}
-.res-nightmode .tabmenu.formtab .selected a {background-color: #445f7e!important}
+.res-nightmode .tabmenu.formtab .selected a {background-color: $primary-color-nightmode!important}
 .res-nightmode .submit-page .roundfield {
 	background-color: #2f2f2f!important;
 	border-color: #0f0f0f

--- a/src/_header.scss
+++ b/src/_header.scss
@@ -1,16 +1,23 @@
 $header-snoo-reserved-width: $header-snoo-width + 2 * $header-snoo-padding-horizontal;
 // Temporary header background override for special events
 $header-background: url("images/header.png") center left/auto 100% #213553 no-repeat;
+$header-background-nightmode: $header-background;
 
 #header {
 	height: $header-height;
-	background: $header-background;
 	border-bottom: 0;
 	box-shadow: 0 1px 2px rgba(0,0,0,0.2);
 
-	@include nightmode {
-		html & { // specificity hack
-			background: $primary-color-nightmode;
+	// Slight optimization - if we use the same header for light and dark modes,
+	// we can just use !important instead of explicitly styling for nightmode
+	@if $header-background == $header-background-nightmode {
+		background: $header-background !important;
+	} @else {
+		background: $header-background;
+		@include nightmode {
+			html & { // specificity hack
+				background: $header-background-nightmode;
+			}
 		}
 	}
 }

--- a/src/_header.scss
+++ b/src/_header.scss
@@ -1,7 +1,4 @@
 $header-snoo-reserved-width: $header-snoo-width + 2 * $header-snoo-padding-horizontal;
-// Temporary header background override for special events
-$header-background: url("images/header.png") center left/auto 100% #213553 no-repeat;
-$header-background-nightmode: $header-background;
 
 #header {
 	height: $header-height;

--- a/src/_header.scss
+++ b/src/_header.scss
@@ -10,7 +10,7 @@ $header-background: url("images/header.png") center left/auto 100% #213553 no-re
 
 	@include nightmode {
 		html & { // specificity hack
-			background: #445f7e;
+			background: $primary-color-nightmode;
 		}
 	}
 }

--- a/src/_header.scss
+++ b/src/_header.scss
@@ -11,7 +11,7 @@ $header-background: url("images/header.png") center left/auto 100% #213553 no-re
 
 // Subreddits bar at the very top of the page
 #sr-header-area {
-	background: rgba(0, 0, 0, 0.2);
+	background: $primary-secondary-shadow;
 	border-bottom: 0;
 	color: #FFF;
 	// text-transform: none;
@@ -60,7 +60,7 @@ $header-background: url("images/header.png") center left/auto 100% #213553 no-re
 	position: absolute;
 	bottom: 0;
 	// use box-shadow to give tab menu a background
-	box-shadow: inset 0 (-$header-tabmenu-height) rgba(0, 0, 0, 0.2);
+	box-shadow: inset 0 (-$header-tabmenu-height) $primary-secondary-shadow;
 	// stretch background to both edges of header
 	left: 0;
 	right: 0;

--- a/src/_header.scss
+++ b/src/_header.scss
@@ -7,16 +7,29 @@ $header-background: url("images/header.png") center left/auto 100% #213553 no-re
 	background: $header-background;
 	border-bottom: 0;
 	box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+
+	@include nightmode {
+		html & { // specificity hack
+			background: #445f7e;
+		}
+	}
 }
 
 // Subreddits bar at the very top of the page
 #sr-header-area {
-	background: $primary-secondary-shadow;
+	background-color: $primary-secondary-shadow;
 	border-bottom: 0;
 	color: #FFF;
 	// text-transform: none;
 	// font-size: 12px;
 	// line-height: 18px
+
+	@include nightmode {
+		html & { // specificity hack
+			background: $primary-secondary-shadow-nightmode;
+		}
+	}
+
 	.dropdown.srdrop .selected {
 		color: #FFF;
 		background-image: none;
@@ -68,6 +81,10 @@ $header-background: url("images/header.png") center left/auto 100% #213553 no-re
 	z-index: -1;
 	// leave space for snoo
 	padding-left: $header-snoo-reserved-width;
+
+	@include nightmode {
+		box-shadow: inset 0 (-$header-tabmenu-height) $primary-secondary-shadow-nightmode;
+	}
 }
 
 // Snoo
@@ -157,6 +174,11 @@ $header-background: url("images/header.png") center left/auto 100% #213553 no-re
 		height: 8px;
 		background: #FFF;
 		box-shadow: inset 2px 2px 2px -1px rgba(0,0,0,0.2),1px 1px 1px #FFF;
+
+		@include nightmode {
+			background: #2f2f2f;
+			box-shadow: inset 2px 2px 2px -1px rgba(0, 0, 0, 0.2), 1px 1px 1px #2f2f2f;
+		}
 	}
 }
 

--- a/src/_infobar.scss
+++ b/src/_infobar.scss
@@ -81,7 +81,7 @@ body > .content {
 			position: relative !important;
 			z-index: 2;
 			@include nightmode {
-				background: #445f7e !important;
+				background: $primary-color-nightmode !important;
 			}
 		}
 
@@ -115,7 +115,7 @@ body > .content {
 			border-top: $infobar-dropdown-border-width solid $infobar-dropdown-border-color;
 			box-shadow: $dropdown-shadow;
 			@include nightmode {
-				border-color: #445f7e;
+				border-color: $primary-color-nightmode;
 			}
 		}
 	}

--- a/src/util/_vars.scss
+++ b/src/util/_vars.scss
@@ -43,6 +43,7 @@ $sidebar-control-height: 35px;
 
 // Image customization and stuff
 $header-background: $primary-color; 
+$header-background-nightmode: $primary-color-nightmode;
 $sidebar-background: repeating-linear-gradient(45deg, #f7f7f7, #f7f7f7 2px, #e9e9e9 2px, #e9e9e9 2.8px) 0/4px 4px;
 
 // Derived variables

--- a/src/util/_vars.scss
+++ b/src/util/_vars.scss
@@ -6,8 +6,14 @@ $base-border-radius: 5px;
 $base-border-radius-small: 3px;
 
 // Colors
+
+// "Brand" colors
 $primary-color: #6A9DE6;
-$secondary-color: #557EB8;
+// We construct the secondary color from the primary color and a black overlay
+$darken-ratio: 0.2;
+$secondary-color: mix($color-primary, black, 100% * (1 - $darken-ratio));
+// We can also achieve the secondary color by adding a shadow to the primary
+$primary-secondary-shadow: rgba(0, 0, 0, $darken-ratio);
 
 $base-background-color: #FFF;
 $separator-color: #CFCFCF;

--- a/src/util/_vars.scss
+++ b/src/util/_vars.scss
@@ -9,11 +9,17 @@ $base-border-radius-small: 3px;
 
 // "Brand" colors
 $primary-color: #6A9DE6;
+$primary-color-nightmode: #445F7E;
+
 // We construct the secondary color from the primary color and a black overlay
 $darken-ratio: 0.2;
-$secondary-color: mix($color-primary, black, 100% * (1 - $darken-ratio));
+$secondary-color: mix($primary-color, black, 100% * (1 - $darken-ratio));
+$darken-ratio-nightmode: 0.3;
+$secondary-color-nightmode: mix($primary-color, black, 100% * (1 - $darken-ratio));
+
 // We can also achieve the secondary color by adding a shadow to the primary
 $primary-secondary-shadow: rgba(0, 0, 0, $darken-ratio);
+$primary-secondary-shadow-nightmode: rgba(0, 0, 0, $darken-ratio-nightmode);
 
 $base-background-color: #FFF;
 $separator-color: #CFCFCF;

--- a/src/util/_vars.scss
+++ b/src/util/_vars.scss
@@ -15,7 +15,7 @@ $primary-color-nightmode: #445F7E;
 $darken-ratio: 0.2;
 $secondary-color: mix($primary-color, black, 100% * (1 - $darken-ratio));
 $darken-ratio-nightmode: 0.3;
-$secondary-color-nightmode: mix($primary-color, black, 100% * (1 - $darken-ratio));
+$secondary-color-nightmode: mix($primary-color-nightmode, black, 100% * (1 - $darken-ratio));
 
 // We can also achieve the secondary color by adding a shadow to the primary
 $primary-secondary-shadow: rgba(0, 0, 0, $darken-ratio);


### PR DESCRIPTION
Slightly changes nightmode color styles. Defines the secondary theme color as a mix of the primary color and black - this enables us to keep transparency effects in the header menus when custom banners are presented without duplicating too much generated code. Also moved header nightmode styles out of `_everything.scss` as part of this cleanup.