### PR TITLE
Replace libsass with Dart Sass CLI

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -18,8 +18,6 @@ jobs:
         python-version: '3.6'
     - name: Install pip requirements
       run: pip install -r utils/requirements.txt
-    - name: Install Sass CLI
-      run: npm install sass
     - name: Build and some other testing stuff
       run: |
         echo ${{ github.ref }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -18,6 +18,8 @@ jobs:
         python-version: '3.6'
     - name: Install pip requirements
       run: pip install -r utils/requirements.txt
+    - name: Install Sass CLI
+      run: npm install --global sass
     - name: Build and some other testing stuff
       run: |
         echo ${{ github.ref }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install pip requirements
       run: pip install -r utils/requirements.txt
     - name: Install Sass CLI
-      run: npm install --global sass
+      run: npm install sass
     - name: Build and some other testing stuff
       run: |
         echo ${{ github.ref }}

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,5 +1,4 @@
 praw
-libsass
 csscompressor
 click
 Pillow

--- a/utils/stylesheet/stylesheet_assets_builder.py
+++ b/utils/stylesheet/stylesheet_assets_builder.py
@@ -92,7 +92,7 @@ class StylesheetAssetsBuilder:
             ["sass", "--no-charset", "main.scss"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
+            universal_newlines=True,
         )
         if process.stderr:
             raise SassCompileException(process.stderr, sass_file.name)

--- a/utils/stylesheet/stylesheet_assets_builder.py
+++ b/utils/stylesheet/stylesheet_assets_builder.py
@@ -89,7 +89,7 @@ class StylesheetAssetsBuilder:
 
         logger.debug("Compiling the Sass file.")
         process = subprocess.run(
-            ["sass", "--no-charset", "main.scss"],
+            ["npx", "-q", "sass", "--no-charset", "main.scss"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,

--- a/utils/stylesheet/stylesheet_assets_builder.py
+++ b/utils/stylesheet/stylesheet_assets_builder.py
@@ -4,7 +4,7 @@ import os
 import re
 
 import csscompressor
-import sass
+import subprocess
 from ruamel.yaml import YAML
 
 from stylesheet import (LocalStylesheetImage, RemoteStylesheetImage,
@@ -87,11 +87,21 @@ class StylesheetAssetsBuilder:
         logger.debug("Reading the Sass file.")
         sass_content = sass_file.read()
 
-        try:
-            logger.debug("Compiling the Sass file.")
-            css_content = sass.compile(filename=sass_file.name)
-        except sass.CompileError as error:
-            raise SassCompileException(error, sass_file.name)
+        logger.debug("Compiling the Sass file.")
+        process = subprocess.run(
+            ["sass", "--no-charset", "main.scss"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if process.stderr:
+            raise SassCompileException(process.stderr, sass_file.name)
+        if process.returncode != 0:
+            raise SassCompileException(
+                f"Sass gave non-zero exit code {process.returncode}",
+                sass_file.name,
+            )
+        css_content = process.stdout
         logger.debug(
             "Compiled the Sass file. CSS content size: {} bytes".format(
                 len(css_content),

--- a/utils/stylesheet_exceptions.py
+++ b/utils/stylesheet_exceptions.py
@@ -1,6 +1,4 @@
 """Stylesheet exception classes."""
-from sass import CompileError
-
 
 class StylesheetException(Exception):
     """The base Stylesheet Exception that all other exception classes extend.
@@ -20,10 +18,10 @@ class SassCompileException(StylesheetException):
     The specific information about errors in included in the error message.
     """
 
-    def __init__(self, compile_error: CompileError, filename):
+    def __init__(self, error_message, filename):
         """Construct an instance of SassCompileException."""
         message = (f"An error occurred when compiling the Sass file "
-        f"{filename}:\n {str(compile_error)}")
+        f"{filename}:\n{str(error_message)}")
         super().__init__(message)
         self.filename = filename
 


### PR DESCRIPTION
Among other things, this lets us take advantage of the modern Sass module system and `@use` directives. Un-blocks #63.