### PR TITLE
Flair timing fix and cleanup

### DIFF
--- a/src/_userflair.scss
+++ b/src/_userflair.scss
@@ -13,6 +13,11 @@
 	color: #3e5267 !important;
 	cursor: default;
 	transition: 200ms 350ms;
+
+	// All elements of the flair inherit the same transition properties
+	* {
+		transition: inherit;
+	}
 }
 
 // Expand the flair on hover

--- a/src/_userflair.scss
+++ b/src/_userflair.scss
@@ -12,22 +12,29 @@
 	font-size: 0 !important;
 	color: #3e5267 !important;
 	cursor: default;
+
+	// 200ms smooth transition from normal to hover and back. When going from
+	// hovered back to normal, delay for 350ms in case the user was trying to
+	// select the flair text and their mouse briefly left the flair area
+	// accidentally.
 	transition: 200ms 350ms;
 
 	// All elements of the flair inherit the same transition properties
 	* {
 		transition: inherit;
 	}
-}
 
-// Expand the flair on hover
-.flair:hover {
-	width: auto;
-	font-size: x-small !important;
-	transition-delay: 0s
-}
+	// Expand the flair on hover
+	:hover {
+		width: auto;
+		font-size: x-small !important;
 
-// Give some margin to the text component of the flair for readability
-.flair:hover > :not([class]) {
-	margin: 0 5px;
+		// No delay when going from normal to hover, open the flair immediately
+		transition-delay: 0ms;
+
+		// Give some margin to the text component of the flair for readability
+		> :not([class]) {
+			margin: 0 5px;
+		}
+	}
 }


### PR DESCRIPTION
Fixes an issue introduced by #81 where the margin given to flair text didn't animate consistently with the rest of the flair's closing animation because of `transition` not being inherited. Also reorganizes the file to use nested selectors and adds some comments.