### PR TITLE
Update actions used in deploy workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -75,11 +75,11 @@ jobs:
         fi
 
     - name: Create GitHub deployment
-      uses: chrnorm/deployment-action@v1.0.0
+      uses: chrnorm/deployment-action@v2
       id: deployment
       with:
         token: ${{ github.token }}
-        target_url: https://old.reddit.com/r/${{ steps.target.outputs.subreddit }}
+        environment-url: https://old.reddit.com/r/${{ steps.target.outputs.subreddit }}
         environment: ${{ steps.target.outputs.environment }}
 
     - name: Deploy
@@ -91,7 +91,7 @@ jobs:
 
     - name: Update deployment status (success)
       if: success()
-      uses: chrnorm/deployment-status@v1.0.0
+      uses: chrnorm/deployment-status@v2
       with:
         token: ${{ github.token }}
         state: success
@@ -99,7 +99,7 @@ jobs:
 
     - name: Update deployment status (failure)
       if: failure()
-      uses: chrnorm/deployment-status@v1.0.0
+      uses: chrnorm/deployment-status@v2
       with:
         token: ${{ github.token }}
         state: failure

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -95,7 +95,7 @@ jobs:
       with:
         token: ${{ github.token }}
         state: success
-        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+        deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
     - name: Update deployment status (failure)
       if: failure()
@@ -103,4 +103,4 @@ jobs:
       with:
         token: ${{ github.token }}
         state: failure
-        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+        deployment-id: ${{ steps.deployment.outputs.deployment_id }}


### PR DESCRIPTION
Fixes some deprecation warnings generated by `chrnorm/deployment-action@v1` still relying on the old `::set-output` syntax. Being up to date is good