### PR TITLE
Fix remaining uses of %display-none

### DIFF
--- a/src/_header.scss
+++ b/src/_header.scss
@@ -136,7 +136,7 @@ $header-snoo-reserved-width: vars.$header-snoo-width + 2 * vars.$header-snoo-pad
 *
 *#header-img {
 *	@include mixins.nightmode {
-*		@extend %display-none !optional;
+*		@extend %display-none;
 *	}
 *}
 *

--- a/src/_sidebar.scss
+++ b/src/_sidebar.scss
@@ -1,3 +1,4 @@
+@use "util/mixins";
 @use "util/vars";
 
 // Align the search icon better with our search style
@@ -17,7 +18,7 @@
 
 // If an ad doesn't load, get rid of the big gap it leaves behind
 .ad-container:empty {
-	@extend %display-none !optional;
+	@extend %display-none;
 }
 
 // Markdown headings
@@ -112,7 +113,7 @@
 	font-size: 0;
 }
 .titlebox .bottom .flair {
-	@extend %display-none !optional;
+	@extend %display-none;
 }
 .titlebox .bottom .age {
 	font-size: x-small;
@@ -120,5 +121,5 @@
 
 // Hide "create a subreddit" button
 .sidebox.create {
-	@extend %display-none !optional;
+	@extend %display-none;
 }

--- a/src/_thumbnails.scss
+++ b/src/_thumbnails.scss
@@ -1,5 +1,7 @@
 // Custom thumbnail image handling
 
+@use "util/mixins";
+
 // Default Reddit classes
 .thumbnail.self {background: 0 -1084px}
 .thumbnail.spoiler {background: 0 -1154px}
@@ -37,6 +39,6 @@
 .linkflair-fanart,
 .linkflair-fanart-oc {
 	.thumbnail img {
-		@extend %display-none !optional;
+		@extend %display-none;
 	}
 }


### PR DESCRIPTION
#122 converted the project from `@import` to `@use`. In locations where `@extend %display-none` was used, it seems like instead of importing the file where that placeholder is defined, all the extensions were changed to use `!optional` instead - which silences the error about the placeholder not being defined, but also causes there to be no output for the rule. This means that a bunch of stuff that was supposed to be hidden no longer was.

7f6b9c3 fixed this issue for post filters. This PR applies the same fix to everything else that was broken for the same reason:

- Fanart thumbnail replacement
- Nightmode-specific snoo
- Hiding unloaded ad containers to fix sidebar spacing
- Hiding the "create a subreddit" button from the sidebar