### PR TITLE
Re-enable nightmode snoo

### DIFF
--- a/src/_header.scss
+++ b/src/_header.scss
@@ -1,6 +1,10 @@
 @use "util/mixins";
 @use "util/vars";
 
+// Set to `false` if there'a temporary custom snoo that we want to show up in
+// nightmode as well; set to `true` when using the standard snoo
+$use-nightmode-snoo: true;
+
 $header-snoo-reserved-width: vars.$header-snoo-width + 2 * vars.$header-snoo-padding-horizontal;
 
 #header {
@@ -131,18 +135,20 @@ $header-snoo-reserved-width: vars.$header-snoo-width + 2 * vars.$header-snoo-pad
 	height: vars.$header-snoo-height;
 }
 
-// In nightmode, display a custom image in a pseudo-element
-#header-img {
-	@include mixins.nightmode {
-		@extend %display-none;
+@if $use-nightmode-snoo {
+	// In nightmode, display a custom image in a pseudo-element
+	#header-img {
+		@include mixins.nightmode {
+			@extend %display-none;
+		}
 	}
-}
 
-#header-img-a::after {
-	@include mixins.nightmode {
-		content: "";
-		display: block;
-		background: url("images/general.png") 0 -172px/128px;
+	#header-img-a::after {
+		@include mixins.nightmode {
+			content: "";
+			display: block;
+			background: url("images/general.png") 0 -172px/128px;
+		}
 	}
 }
 

--- a/src/_header.scss
+++ b/src/_header.scss
@@ -132,22 +132,19 @@ $header-snoo-reserved-width: vars.$header-snoo-width + 2 * vars.$header-snoo-pad
 }
 
 // In nightmode, display a custom image in a pseudo-element
-/* Temporary removal of nightmode snoo for the Christmas season.
-*
-*#header-img {
-*	@include mixins.nightmode {
-*		@extend %display-none;
-*	}
-*}
-*
-*#header-img-a::after {
-*	@include mixins.nightmode {
-*		content: "";
-*		display: block;
-*		background: url("images/general.png") 0 -172px/128px;
-*	}
-*}
-*/
+#header-img {
+	@include mixins.nightmode {
+		@extend %display-none;
+	}
+}
+
+#header-img-a::after {
+	@include mixins.nightmode {
+		content: "";
+		display: block;
+		background: url("images/general.png") 0 -172px/128px;
+	}
+}
 
 // Sub name and page info
 .pagename {
@@ -193,7 +190,7 @@ $header-snoo-reserved-width: vars.$header-snoo-width + 2 * vars.$header-snoo-pad
 		font-weight: 400;
 		height: vars.$header-tabmenu-height;
 		position: relative;
-		
+
 		&:hover {
 			background: rgba(0,0,0,.1);
 		}


### PR DESCRIPTION
Follow-up to #126 (removed Christmas styles and reverted to the normal snoo) and #130 (fixed the code for the nightmode snoo). Also adds a variable that can just be changed from `true` to `false` to disable the nightmode snoo replacement for special occasions.