### PR TITLE
Fix uploads of transparent images

### DIFF
--- a/build/util/RedditAPIClient.ts
+++ b/build/util/RedditAPIClient.ts
@@ -156,7 +156,6 @@ export class RedditAPIClient {
 			method: 'POST',
 			body: multipartFormDataBody({
 				upload_type: 'img',
-				img_type: 'jpg',
 				name: name,
 				file: new Blob([data]),
 			}),


### PR DESCRIPTION
Fixes an issue with #128 that caused all images to be uploaded as JPEGs which removed transparency from PNGs