### PR TITLE
Style new notification icons in userbar

### DIFF
--- a/src/_header.scss
+++ b/src/_header.scss
@@ -231,3 +231,12 @@ $header-snoo-reserved-width: vars.$header-snoo-width + 2 * vars.$header-snoo-pad
 #header-bottom-right a {
 	color: #FFF;
 }
+
+// make new notification icons look slightly better
+#notifications, #chat-v2 {
+	filter: brightness(999); // change icon color from black-ish to white
+	width: 16px;
+	height: 16px;
+	background-size: 16px;
+	top: 4px; // match positioning of modmail icon
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fe59cbf8-e88f-409a-a2fb-621f7b213c7d)

Presumably these new icons are rolling out due to [the replacement of PMs with Chat](https://www.reddit.com/r/reddit/comments/1jf1bxy/private_messages_will_be_replaced_with_reddit/). from [the FAQ](https://www.reddit.com/r/reddit/comments/1jf1bxy/private_messages_will_be_replaced_with_reddit/min90n8/):

> - I only use old Reddit. Will there be any UI changes that I should expect on old Reddit?
>
>   - Old Reddit will receive small UI updates to allow users to access all information previously provided via PMs